### PR TITLE
Avoid invoking callback twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var resolve = require('path').resolve;
 module.exports = function(directory, callback) {
   fs.stat(resolve(directory), function(err, stat) {
     if (err) {
-      callback(false);
+      return callback(false);
     }
     callback(stat.isDirectory());
   });


### PR DESCRIPTION
The async function throws if path does not exist.

```
    callback(stat.isDirectory());
                 ^

TypeError: Cannot read property 'isDirectory' of undefined
```

This patch forces an early exit.