### PR TITLE
Node-style callbacks to allow promisify

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ var resolve = require('path').resolve;
 module.exports = function(directory, callback) {
   fs.stat(resolve(directory), function(err, stat) {
     if (err) {
-      return callback(false);
+      return callback(null, false);
     }
-    callback(stat.isDirectory());
+    callback(null, stat.isDirectory());
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "path",
     "paths",
     "system"
-
   ],
   "author": "timmydoza <timmydoza@gmail.com>",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,8 @@ $ npm install --save directory-exists
 
 ```js
 const directoryExists = require('directory-exists');
-directoryExists(directory, callback(result) {
-  // returns boolean
+directoryExists(directory, callback(error, result) {
+  // result is a boolean
 };
 ```
 
@@ -24,7 +24,7 @@ directoryExists(directory, callback(result) {
 ```js
 const directoryExists = require('directory-exists');
 
-directoryExists.sync(directory); //retuns boolean
+directoryExists.sync(directory); // retuns a boolean
 ```
 
 ## Why not use the `fs.exists`?

--- a/test/directory-exists-test.js
+++ b/test/directory-exists-test.js
@@ -5,21 +5,21 @@ var directoryExists = require(__dirname + '/../index.js');
 
 describe('The directoryExists function', function() {
   it('return true if a directory exists and is a directory', function(done) {
-    var result = directoryExists(__dirname, function(result) {
+    var result = directoryExists(__dirname, function(error, result) {
     expect(result).to.eql(true);
     setImmediate(done);
     });
   });
 
   it('should return false if path does not exist', function(done) {
-    var result = directoryExists(__dirname + '/fakeDirectory', function(result) {
+    var result = directoryExists(__dirname + '/fakeDirectory', function(error, result) {
     expect(result).to.eql(false);
     setImmediate(done);
     });
   });
 
   it('should return false if path is a file', function(done) {
-    var result = directoryExists(__dirname + '/directory-exists-test.js', function(result) {
+    var result = directoryExists(__dirname + '/directory-exists-test.js', function(error, result) {
     expect(result).to.eql(false);
     setImmediate(done);
     });


### PR DESCRIPTION
Using `require('util').promisify` requires the first argument to be an error (or `null`).

This patch is a breaking change. Bump major version before publishing to NPM.